### PR TITLE
Implements tutorial context switching

### DIFF
--- a/src/game/end_mining.gd
+++ b/src/game/end_mining.gd
@@ -2,6 +2,21 @@ class_name EndMining
 extends CanvasLayer
 
 @export var chip_labels: Dictionary [Enum.MiningResourceType, Label]
+@export var tutorial_context: GUIDEMappingContext
+@export var tutorial_next: GUIDEAction
+
+
+func _ready() -> void:
+	visibility_changed.connect(_on_visibility_changed)
+
+
+func _on_visibility_changed():
+	if !visible:
+		return
+
+	Service.Guide.set_local_context(tutorial_context)
+	tutorial_next.triggered.connect(_on_button_pressed)
+	$Button.grab_focus()
 
 
 func _on_button_pressed() -> void:

--- a/src/game/end_mining.tscn
+++ b/src/game/end_mining.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://d1q8xcp42pnas"]
+[gd_scene load_steps=8 format=3 uid="uid://d1q8xcp42pnas"]
 
 [ext_resource type="Script" uid="uid://xev43a1md78r" path="res://game/end_mining.gd" id="1_wrppg"]
+[ext_resource type="Resource" uid="uid://usvvwpk3jfux" path="res://input/tutorial/tutorial_context.tres" id="2_cqwx5"]
 [ext_resource type="Texture2D" uid="uid://drgb84dfv17xp" path="res://assets/resources/memory/chip_blue.png" id="2_piox7"]
+[ext_resource type="Resource" uid="uid://fpfhuuxfwr23" path="res://input/tutorial/actions/next.tres" id="3_2vukn"]
 [ext_resource type="Texture2D" uid="uid://dgicfkr54srxn" path="res://assets/resources/memory/chip_green.png" id="3_nj2gt"]
 [ext_resource type="Texture2D" uid="uid://dtiej8ruxskwl" path="res://assets/resources/memory/chip_red.png" id="4_cqwx5"]
 [ext_resource type="Texture2D" uid="uid://bt23ug0kj206j" path="res://assets/resources/memory/chip_yellow.png" id="5_2vukn"]
@@ -17,6 +19,8 @@ chip_labels = {
 2: NodePath("PanelContainer/MarginContainer/GridContainer/ChipRed Label"),
 3: NodePath("PanelContainer/MarginContainer/GridContainer/ChipYellow Label")
 }
+tutorial_context = ExtResource("2_cqwx5")
+tutorial_next = ExtResource("3_2vukn")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 anchors_preset = 15

--- a/src/game/mining_area.gd
+++ b/src/game/mining_area.gd
@@ -10,8 +10,6 @@ var time_left: float
 
 
 func _ready():
-	Service.Guide.add_local_context(input_context)
-
 	total_mining_time = Service.Upgrade.get_upgrade_value(Enum.UpgradeType.MINE_TIME, "time")
 	time_left = total_mining_time
 

--- a/src/game/start_countdown.gd
+++ b/src/game/start_countdown.gd
@@ -1,8 +1,12 @@
 extends CanvasLayer
 
-@export var countdown_time: int = 3
-
 signal on_countdown_finished()
+
+@export var main_context: GUIDEMappingContext
+@export var tutorial_context: GUIDEMappingContext
+@export var tutorial_next: GUIDEAction
+
+@export var countdown_time: int = 3
 
 var elapsed_time: float = 0
 
@@ -11,6 +15,7 @@ var elapsed_time: float = 0
 
 func _ready() -> void:
 	pause_game.call_deferred()
+	tutorial_next.triggered.connect(_on_tutorial_next_triggered)
 
 
 func _process(delta: float) -> void:
@@ -28,6 +33,10 @@ func _process(delta: float) -> void:
 			end_countdown()
 
 
+func _on_tutorial_next_triggered():
+	%ContinueButton.pressed.emit()
+
+
 func pause_game():
 	get_tree().paused = true
 
@@ -36,8 +45,16 @@ func end_countdown():
 	$CountdownLabel.hide()
 	if State.Tutorial.should_show_mining_tutorial:
 		State.Tutorial.should_show_mining_tutorial = false
+
+		%ContinueButton.grab_focus()
+		Service.Guide.set_local_context(tutorial_context)
+
 		$Tutorial.show()
 		await %ContinueButton.pressed
+
+		Service.Guide.set_local_context.call_deferred(main_context)
+	else:
+		Service.Guide.set_local_context.call_deferred(main_context)
 
 	get_tree().paused = false
 	hide()

--- a/src/game/start_countdown.tscn
+++ b/src/game/start_countdown.tscn
@@ -1,8 +1,11 @@
-[gd_scene load_steps=13 format=3 uid="uid://cnxuqu35cj1mi"]
+[gd_scene load_steps=16 format=3 uid="uid://cnxuqu35cj1mi"]
 
 [ext_resource type="Script" uid="uid://bkgvdcll8rl" path="res://game/start_countdown.gd" id="1_yva5m"]
+[ext_resource type="Resource" uid="uid://b21g17kle5gak" path="res://input/game/mining_context.tres" id="2_0tcns"]
 [ext_resource type="Texture2D" uid="uid://cdv8dmm86lhak" path="res://assets/characters/chipmunk/portrait/cpor1.png" id="2_7rwqi"]
+[ext_resource type="Resource" uid="uid://usvvwpk3jfux" path="res://input/tutorial/tutorial_context.tres" id="3_1b3rj"]
 [ext_resource type="Texture2D" uid="uid://dja42r1s07753" path="res://assets/resources/pickaxe/pickaxe.png" id="3_1ujmk"]
+[ext_resource type="Resource" uid="uid://fpfhuuxfwr23" path="res://input/tutorial/actions/next.tres" id="4_67fc3"]
 [ext_resource type="Texture2D" uid="uid://c6runtmx1soam" path="res://assets/resources/boom/boom0.png" id="4_qfrmk"]
 [ext_resource type="Texture2D" uid="uid://drgb84dfv17xp" path="res://assets/resources/memory/chip_blue.png" id="5_1vo6a"]
 [ext_resource type="Texture2D" uid="uid://dgicfkr54srxn" path="res://assets/resources/memory/chip_green.png" id="6_msh8x"]
@@ -17,6 +20,9 @@
 process_mode = 3
 layer = 2
 script = ExtResource("1_yva5m")
+main_context = ExtResource("2_0tcns")
+tutorial_context = ExtResource("3_1b3rj")
+tutorial_next = ExtResource("4_67fc3")
 
 [node name="ColorRect" type="ColorRect" parent="."]
 anchors_preset = 15

--- a/src/game/upgrades/time_upgrade.gd
+++ b/src/game/upgrades/time_upgrade.gd
@@ -10,7 +10,7 @@ func get_upgrade_keys() -> Array[String]:
 	return ["time"]
 
 
-func can_upgrade_to(level: int) -> bool:
+func can_upgrade_to(_level: int) -> bool:
 	return true
 
 

--- a/src/game/upgrades/upgrade_resource.gd
+++ b/src/game/upgrades/upgrade_resource.gd
@@ -9,17 +9,17 @@ func get_upgrade_keys() -> Array[String]:
 	return []
 
 
-func can_upgrade_to(level: int) -> bool:
+func can_upgrade_to(_level: int) -> bool:
 	return false
 
 
-func get_upgrade_value(key: String, level: int) -> float:
+func get_upgrade_value(_key: String, _level: int) -> float:
 	return 0.0
 
 
-func get_upgrade_cost(level: int) -> int:
+func get_upgrade_cost(_level: int) -> int:
 	return 0
 
 
-func get_key_name(key: String) -> String:
+func get_key_name(_key: String) -> String:
 	return ""

--- a/src/home_base/home_base.gd
+++ b/src/home_base/home_base.gd
@@ -1,21 +1,25 @@
 extends Node2D
 
-@export var input_context: GUIDEMappingContext
+@export var tutorial_next: GUIDEAction
+@export var main_context: GUIDEMappingContext
+@export var tutorial_context: GUIDEMappingContext
 
 @onready var boundary: TileMapLayer = %Boundary
 @onready var camera: Camera2D = %Camera2D
 
+@onready var tutorial_buttons: Array[Button] = [%Step1Button, %Step2Button, %Step3Button, %Step4Button, %Step5Button, %Step6Button, %Step7Button, %Step8Button]
+
 
 func _ready() -> void:
 	_set_camera_limit()
-
-	Service.Guide.add_local_context(input_context)
 
 	Service.Market.fluctuate_prices()
 
 	if State.Tutorial.should_show_opening_tutorial:
 		State.Tutorial.should_show_opening_tutorial = false
 		_show_tutorial()
+	else:
+		Service.Guide.set_local_context(main_context)
 
 
 ## Sets the camera limits based on the boundary tilemap.
@@ -36,39 +40,60 @@ func _set_camera_limit():
 
 
 func _show_tutorial():
+	Service.Guide.set_local_context(tutorial_context)
+	tutorial_next.triggered.connect(_on_tutorial_next_triggered)
+
 	get_tree().paused = true
+
 	$Tutorial.show()
 	$Tutorial/Step1.show()
+	%Step1Button.grab_focus()
 	await %Step1Button.pressed
 	$Tutorial/Step1.hide()
 
 	$Tutorial/Step2.show()
+	%Step2Button.grab_focus()
 	await %Step2Button.pressed
 	$Tutorial/Step2.hide()
 
 	$Tutorial/Step3.show()
+	%Step3Button.grab_focus()
 	await %Step3Button.pressed
 	$Tutorial/Step3.hide()
 
 	$Tutorial/Step4.show()
+	%Step4Button.grab_focus()
 	await %Step4Button.pressed
 	$Tutorial/Step4.hide()
 
 	$Tutorial/Step5.show()
+	%Step5Button.grab_focus()
 	await %Step5Button.pressed
 	$Tutorial/Step5.hide()
 
 	$Tutorial/Step6.show()
+	%Step6Button.grab_focus()
 	await %Step6Button.pressed
 	$Tutorial/Step6.hide()
 
 	$Tutorial/Step7.show()
+	%Step7Button.grab_focus()
 	await %Step7Button.pressed
 	$Tutorial/Step7.hide()
 
 	$Tutorial/Step8.show()
+	%Step8Button.grab_focus()
 	await %Step8Button.pressed
 	$Tutorial/Step8.hide()
 
 	$Tutorial.hide()
 	get_tree().paused = false
+
+	Service.Guide.set_local_context(main_context)
+
+
+func _on_tutorial_next_triggered():
+	for button in tutorial_buttons:
+		if button.find_parent("Step*").visible:
+			button.pressed.emit.call_deferred()
+			return

--- a/src/home_base/home_base.tscn
+++ b/src/home_base/home_base.tscn
@@ -1,9 +1,11 @@
-[gd_scene load_steps=21 format=4 uid="uid://c1tb7gaxku0hi"]
+[gd_scene load_steps=23 format=4 uid="uid://c1tb7gaxku0hi"]
 
 [ext_resource type="Script" uid="uid://dg4cojk1rchie" path="res://home_base/home_base.gd" id="1_md8vl"]
 [ext_resource type="Resource" uid="uid://dl5v5cvk2xg0l" path="res://input/game/home_base_context.tres" id="2_eb3fi"]
+[ext_resource type="Resource" uid="uid://fpfhuuxfwr23" path="res://input/tutorial/actions/next.tres" id="2_sspq3"]
 [ext_resource type="TileSet" uid="uid://cscguflr1waw8" path="res://home_base/home_base_tileset.tres" id="3_fbnj6"]
 [ext_resource type="PackedScene" uid="uid://s1i3pw58usio" path="res://pause/pause_overlay.tscn" id="3_y0i3c"]
+[ext_resource type="Resource" uid="uid://usvvwpk3jfux" path="res://input/tutorial/tutorial_context.tres" id="4_xvcyn"]
 [ext_resource type="PackedScene" uid="uid://bhoynj4y8r6es" path="res://home_base/mining_door.tscn" id="5_n2u6b"]
 [ext_resource type="PackedScene" uid="uid://b8u2mxlaradk6" path="res://home_base/winning_door.tscn" id="6_0g1cd"]
 [ext_resource type="PackedScene" uid="uid://w3gos45ashu4" path="res://home_base/market_prices.tscn" id="7_2f1hc"]
@@ -25,7 +27,9 @@ size = Vector2(116, 196)
 
 [node name="HomeBase" type="Node2D"]
 script = ExtResource("1_md8vl")
-input_context = ExtResource("2_eb3fi")
+tutorial_next = ExtResource("2_sspq3")
+main_context = ExtResource("2_eb3fi")
+tutorial_context = ExtResource("4_xvcyn")
 
 [node name="PauseOverlay" parent="." instance=ExtResource("3_y0i3c")]
 

--- a/src/home_base/mining_door.gd
+++ b/src/home_base/mining_door.gd
@@ -12,6 +12,7 @@ func _on_interacted():
 
 	if _has_remaining_chips():
 		get_tree().paused = true
+
 		for resource_type in ItemTypes.mining_resources:
 			var remaining = State.Inventory.mining_resources.get(resource_type, 0)
 			for i in range(0, remaining):
@@ -19,6 +20,8 @@ func _on_interacted():
 				AudioService.making_power.play()
 
 				await get_tree().create_timer(0.1).timeout
+
+		await get_tree().create_timer(0.25).timeout
 		get_tree().paused = false
 
 	State.Scene.active_scene = "res://game/mining_area.tscn"

--- a/src/home_base/upgrade_port.gd
+++ b/src/home_base/upgrade_port.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 	interactable.can_interact_changed.connect(_on_interact_change)
 
 
-func _on_interact_change(interactable: bool):
+func _on_interact_change(_interactable: bool):
 	if interactable:
 		upgrade_summary.show_summary(type)
 	else:

--- a/src/home_base/upgrade_port.gd
+++ b/src/home_base/upgrade_port.gd
@@ -15,7 +15,7 @@ func _ready() -> void:
 
 
 func _on_interact_change(_interactable: bool):
-	if interactable:
+	if _interactable:
 		upgrade_summary.show_summary(type)
 	else:
 		upgrade_summary.clear_summary()

--- a/src/input/game/mining_context.tres
+++ b/src/input/game/mining_context.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="GUIDEMappingContext" load_steps=33 format=3 uid="uid://b21g17kle5gak"]
+[gd_resource type="Resource" script_class="GUIDEMappingContext" load_steps=34 format=3 uid="uid://b21g17kle5gak"]
 
 [ext_resource type="Script" uid="uid://cpplm41b5bt6m" path="res://addons/guide/guide_action_mapping.gd" id="1_334wx"]
 [ext_resource type="Resource" uid="uid://bci3audsvtd2e" path="res://input/game/actions/move.tres" id="2_6esg8"]
@@ -123,6 +123,10 @@ alt = false
 meta = false
 allow_additional_modifiers = true
 
+[sub_resource type="Resource" id="Resource_83iou"]
+script = ExtResource("11_83iou")
+actuation_threshold = 0.5
+
 [sub_resource type="Resource" id="Resource_hfcah"]
 script = ExtResource("3_v7gd6")
 override_action_settings = false
@@ -131,7 +135,7 @@ display_name = ""
 display_category = ""
 input = SubResource("Resource_6esg8")
 modifiers = Array[ExtResource("5_83iou")]([])
-triggers = Array[ExtResource("8_vyrpk")]([])
+triggers = Array[ExtResource("8_vyrpk")]([SubResource("Resource_83iou")])
 
 [sub_resource type="Resource" id="Resource_v7gd6"]
 script = ExtResource("1_334wx")

--- a/src/input/guide_service.gd
+++ b/src/input/guide_service.gd
@@ -7,8 +7,9 @@ func add_global_context(context: GUIDEMappingContext):
 	GUIDE.enable_mapping_context(context, false)
 
 
-func add_local_context(context: GUIDEMappingContext):
+func set_local_context(context: GUIDEMappingContext):
 	if local_context:
 		GUIDE.disable_mapping_context(local_context)
 
 	GUIDE.enable_mapping_context(context, false)
+	local_context = context

--- a/src/input/tutorial/actions/next.tres
+++ b/src/input/tutorial/actions/next.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="GUIDEAction" load_steps=2 format=3 uid="uid://fpfhuuxfwr23"]
+
+[ext_resource type="Script" uid="uid://cluhc11vixkf1" path="res://addons/guide/guide_action.gd" id="1_31vp8"]
+
+[resource]
+script = ExtResource("1_31vp8")
+name = &""
+action_value_type = 0
+block_lower_priority_actions = true
+emit_as_godot_actions = false
+is_remappable = false
+display_name = ""
+display_category = ""
+metadata/_custom_type_script = "uid://cluhc11vixkf1"

--- a/src/input/tutorial/tutorial_context.tres
+++ b/src/input/tutorial/tutorial_context.tres
@@ -1,0 +1,67 @@
+[gd_resource type="Resource" script_class="GUIDEMappingContext" load_steps=16 format=3 uid="uid://usvvwpk3jfux"]
+
+[ext_resource type="Script" uid="uid://cpplm41b5bt6m" path="res://addons/guide/guide_action_mapping.gd" id="1_lmfau"]
+[ext_resource type="Resource" uid="uid://fpfhuuxfwr23" path="res://input/tutorial/actions/next.tres" id="2_2tqbr"]
+[ext_resource type="Script" uid="uid://dsa1dnifd6w32" path="res://addons/guide/guide_mapping_context.gd" id="2_5bw11"]
+[ext_resource type="Script" uid="uid://mtx1unc2aqn7" path="res://addons/guide/guide_input_mapping.gd" id="3_681rf"]
+[ext_resource type="Script" uid="uid://cw71o87tvdx3q" path="res://addons/guide/inputs/guide_input_key.gd" id="4_7iejo"]
+[ext_resource type="Script" uid="uid://bl8rjl4oaldje" path="res://addons/guide/modifiers/guide_modifier.gd" id="5_n3yc4"]
+[ext_resource type="Script" uid="uid://x74mnwgr08a7" path="res://addons/guide/triggers/guide_trigger.gd" id="6_ml1ee"]
+[ext_resource type="Script" uid="uid://b52rqq28tuqpg" path="res://addons/guide/triggers/guide_trigger_pressed.gd" id="7_76aqx"]
+
+[sub_resource type="Resource" id="Resource_ylcnf"]
+script = ExtResource("4_7iejo")
+key = 69
+shift = false
+control = false
+alt = false
+meta = false
+allow_additional_modifiers = true
+
+[sub_resource type="Resource" id="Resource_bm3ed"]
+script = ExtResource("7_76aqx")
+actuation_threshold = 0.5
+
+[sub_resource type="Resource" id="Resource_qmmex"]
+script = ExtResource("3_681rf")
+override_action_settings = false
+is_remappable = false
+display_name = ""
+display_category = ""
+input = SubResource("Resource_ylcnf")
+modifiers = Array[ExtResource("5_n3yc4")]([])
+triggers = Array[ExtResource("6_ml1ee")]([SubResource("Resource_bm3ed")])
+
+[sub_resource type="Resource" id="Resource_43tij"]
+script = ExtResource("4_7iejo")
+key = 32
+shift = false
+control = false
+alt = false
+meta = false
+allow_additional_modifiers = true
+
+[sub_resource type="Resource" id="Resource_b7x04"]
+script = ExtResource("7_76aqx")
+actuation_threshold = 0.5
+
+[sub_resource type="Resource" id="Resource_y1ipd"]
+script = ExtResource("3_681rf")
+override_action_settings = false
+is_remappable = false
+display_name = ""
+display_category = ""
+input = SubResource("Resource_43tij")
+modifiers = Array[ExtResource("5_n3yc4")]([])
+triggers = Array[ExtResource("6_ml1ee")]([SubResource("Resource_b7x04")])
+
+[sub_resource type="Resource" id="Resource_1a6el"]
+script = ExtResource("1_lmfau")
+action = ExtResource("2_2tqbr")
+input_mappings = Array[ExtResource("3_681rf")]([SubResource("Resource_qmmex"), SubResource("Resource_y1ipd")])
+
+[resource]
+script = ExtResource("2_5bw11")
+display_name = ""
+mappings = Array[ExtResource("1_lmfau")]([SubResource("Resource_1a6el")])
+metadata/_custom_type_script = "uid://dsa1dnifd6w32"

--- a/src/main_menu/main_menu.gd
+++ b/src/main_menu/main_menu.gd
@@ -5,7 +5,7 @@ extends Control
 
 
 func _ready() -> void:
-	Service.Guide.add_local_context(input_context)
+	Service.Guide.set_local_context(input_context)
 	start_action.triggered.connect(_on_start_action_triggered)
 	_music_playing()
 

--- a/src/main_menu/main_menu.tscn
+++ b/src/main_menu/main_menu.tscn
@@ -55,6 +55,7 @@ start_action = ExtResource("2_d3a7t")
 sprite_frames = SubResource("SpriteFrames_tr6y3")
 
 [node name="butSel" type="Button" parent="."]
+visible = false
 layout_mode = 0
 offset_right = 8.0
 offset_bottom = 8.0

--- a/src/mint/recipes/sea_coin_recipe.tres
+++ b/src/mint/recipes/sea_coin_recipe.tres
@@ -1,15 +1,13 @@
-[gd_resource type="Resource" script_class="RecipeResource" load_steps=6 format=3 uid="uid://cm2i87cmnmqyh"]
+[gd_resource type="Resource" script_class="RecipeResource" load_steps=5 format=3 uid="uid://cm2i87cmnmqyh"]
 
 [ext_resource type="Script" uid="uid://b6jprnqs18iyp" path="res://mint/recipes/recipe_resource.gd" id="1_g4s7b"]
 [ext_resource type="Resource" uid="uid://ch0vk4b6srdgp" path="res://market/coins/sea_coin.tres" id="2_bnlhd"]
 [ext_resource type="Script" uid="uid://d0vocvf6us5ft" path="res://game/resources/mining_resource.gd" id="2_k6j1q"]
 [ext_resource type="Resource" uid="uid://dw66prwy4wlku" path="res://game/resources/blue_chip.tres" id="3_rkrpa"]
-[ext_resource type="Resource" uid="uid://0x6y3yw4sskj" path="res://game/resources/yellow_chip.tres" id="5_wugts"]
 
 [resource]
 script = ExtResource("1_g4s7b")
 coin = ExtResource("2_bnlhd")
 resources = Dictionary[ExtResource("2_k6j1q"), int]({
-ExtResource("3_rkrpa"): 2,
-ExtResource("5_wugts"): 2
+ExtResource("3_rkrpa"): 5
 })


### PR DESCRIPTION
Adds tutorial context switching to all using E, Space or Enter to continue during tutorials and end of mining.

This change introduces GUIDE context switching to the tutorial sequences in Home Base, Mining Area, and End Mining screens. It sets the tutorial context when the tutorial is active and restores the main context when it's finished.
